### PR TITLE
Default nRF jammer to CW turbo (dwell=0)

### DIFF
--- a/mobile_app/lib/models/nrf_jam_mode.dart
+++ b/mobile_app/lib/models/nrf_jam_mode.dart
@@ -7,15 +7,15 @@
 class NrfJamModeConfig {
   int paLevel;       // 0-3 (0=MIN -18dBm, 3=MAX → +20dBm with PA)
   int dataRate;      // 0=1Mbps, 1=2Mbps, 2=250Kbps
-  int dwellTimeMs;   // Time on each channel in ms (1-200)
+  int dwellTimeMs;   // Time on each channel in ms (0-200, 0=turbo)
   bool useFlooding;  // false=Constant Carrier (CW), true=Data Flooding
   int floodBursts;   // Number of flood packets per channel hop (1-10)
 
   NrfJamModeConfig({
     this.paLevel = 3,
     this.dataRate = 1,
-    this.dwellTimeMs = 5,
-    this.useFlooding = true,
+    this.dwellTimeMs = 0,
+    this.useFlooding = false,
     this.floodBursts = 3,
   });
 
@@ -40,8 +40,8 @@ class NrfJamModeConfig {
     return NrfJamModeConfig(
       paLevel: data['paLevel'] ?? 3,
       dataRate: data['dataRate'] ?? 1,
-      dwellTimeMs: data['dwellTimeMs'] ?? 5,
-      useFlooding: data['useFlooding'] ?? true,
+      dwellTimeMs: data['dwellTimeMs'] ?? 0,
+      useFlooding: data['useFlooding'] ?? false,
       floodBursts: data['floodBursts'] ?? 3,
     );
   }

--- a/src/modules/nrf/NrfJammer.h
+++ b/src/modules/nrf/NrfJammer.h
@@ -1,14 +1,19 @@
 /**
  * @file NrfJammer.h
- * @brief 2.4 GHz jammer using nRF24L01+ constant carrier and data flooding.
+ * @brief 2.4 GHz jammer using nRF24L01+ constant carrier (CW) as default.
  *
  * Supports multiple jamming modes: full-band, WiFi channels, BLE channels,
  * Bluetooth, BLE advertising, Zigbee, Drone, USB, video, RC, and custom
  * channel range hopping.
  *
- * Uses two jamming strategies depending on the target:
- *  - Constant Carrier (CW): Best for FHSS targets (Bluetooth, Drones)
- *  - Data Flooding (writeFast): Best for channel-specific targets (WiFi, BLE, Zigbee)
+ * Default strategy: Constant Carrier (CW).
+ * The carrier stays on continuously — channel hops only write the RF_CH
+ * register, PLL re-locks in ~130µs with zero carrier gap.  This gives
+ * near-100% TX duty cycle and proven effectiveness via AGC saturation.
+ *
+ * Optional strategy: Data Flooding (writeFast).
+ * Creates packet collisions, best for channel-specific protocols.
+ * User-selectable per mode via config.
  */
 
 #ifndef NRF_JAMMER_H
@@ -76,9 +81,9 @@ struct NrfJamModeInfo {
  *
  * Each of the 12 modes has independent RF parameters (PA, data rate,
  * dwell time, CW vs flooding) that can be adjusted from the app and
- * persisted in flash.  The dwell time is the key parameter for
- * jamming effectiveness: too fast and the target escapes between hops,
- * too slow and you miss FHSS channels.
+ * persisted in flash.  Default: CW turbo (dwell=0) for all modes.
+ * The carrier stays on during hops (PLL re-lock ~130µs, zero gap).
+ * Users can increase dwell or switch to flooding via the app.
  */
 class NrfJammer {
 public:


### PR DESCRIPTION
Switch the firmware and app defaults to use Constant Carrier (CW) turbo mode (dwellTimeMs = 0) with flooding off by default, and update related UI and hopping logic.

Changes:
- mobile_app: set NrfJamModeConfig defaults to dwellTimeMs=0 and useFlooding=false; update nRF screen to show "TURBO" for 0 ms, allow slider min=0/divisions=200, use cached 0 default, and send live mode change command when switching modes while jammer is running.
- firmware (NrfJammer): document CW-as-default strategy, bump NRF_JAM_CFG_VERSION to 4, set all modeConfigs to dwell=0/CW-by-default, update comments explaining turbo behavior and PLL re-lock (~130µs), and modify cwOnChannel to avoid toggling CE (only write RF_CH) so carrier stays on during hops.

Rationale: CW turbo provides near-100% TX duty cycle and reliable disruption (AGC/PLL effects) especially for FHSS targets; data flooding remains available as an optional per-mode strategy. Config version increment reflects the new default behavior and layout.